### PR TITLE
Implement accessibility settings

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,7 @@
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import Keypad from '../components/partials/Keypad';
+import AccessibilityManager from '../components/AccessibilityManager';
 import '@/styles/reset.scss';
 import '@/styles/style.scss';
 
@@ -21,6 +22,7 @@ export default async function RootLayout({ children }) {
             <html lang="ko">
                 {/* MEMO: suppressHydrationWarning={true} 추가하면 extention의 불필요한 코드를 막음 */}
                 <body suppressHydrationWarning={true}>
+                    <AccessibilityManager />
                     <div id="layout">
                         {<Header/>}
                         <div id="content">

--- a/src/components/AccessibilityManager.js
+++ b/src/components/AccessibilityManager.js
@@ -1,0 +1,53 @@
+"use client";
+import { useEffect } from "react";
+import { useStore } from "@/store/useStore";
+import languageData from "@/../public/assets/data/language.json" assert { type: "json" };
+
+export default function AccessibilityManager() {
+  const highContrast = useStore((state) => state.highContrast);
+  const lowPosture = useStore((state) => state.lowPosture);
+  const language = useStore((state) => state.language);
+  const fontSize = useStore((state) => state.fontSize);
+
+  // Update classes on html element
+  useEffect(() => {
+    const html = document.documentElement;
+
+    // high contrast
+    html.classList.toggle("contrast", highContrast);
+
+    // low posture
+    html.classList.toggle("low", lowPosture);
+
+    // language class (except default 'ko')
+    html.classList.remove("en", "jp", "zh");
+    if (language !== "ko") {
+      html.classList.add(language);
+    }
+
+    // font size classes
+    html.classList.remove("font_65", "font_69");
+    if (fontSize === 65) {
+      html.classList.add("font_65");
+    } else if (fontSize === 69) {
+      html.classList.add("font_69");
+    }
+  }, [highContrast, lowPosture, language, fontSize]);
+
+  // Update text contents according to language
+  useEffect(() => {
+    const map = { ko: "KO", en: "EN", jp: "JP", zh: "CH" };
+    const key = map[language];
+    if (!key) return;
+
+    document.querySelectorAll("[data-lang-code]").forEach((el) => {
+      const code = el.getAttribute("data-lang-code");
+      const entry = languageData.find((item) => item.code === code);
+      if (entry && entry[key]) {
+        el.textContent = entry[key];
+      }
+    });
+  }, [language]);
+
+  return null;
+}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -30,8 +30,19 @@
     src: url('https://cdn.jsdelivr.net/gh/fonts-archive/NEXONLv1Gothic/NEXONLv1Gothic-Bold.woff2') format('woff2'),
          url('https://cdn.jsdelivr.net/gh/fonts-archive/NEXONLv1Gothic/NEXONLv1Gothic-Bold.woff') format('woff'),
 }
-html{font-family: 'NEXON Lv1 Gothic';}
+html{font-family: 'NEXON Lv1 Gothic';font-size:62.5%;}
 body{font-size:1.7rem;}
+html.contrast{
+    filter: contrast(1.5);
+}
+html.low{
+    scroll-behavior: smooth;
+}
+html.en, html.jp, html.zh{
+    font-family: 'NEXON Lv1 Gothic';
+}
+html.font_65{font-size:65%;}
+html.font_69{font-size:69%;}
 *:focus{ outline-offset: 1px;outline:3px dashed rgb(244, 122, 0);}
 ::selection {background: #04a145;color: #fff;}
 .sound_only {position: absolute;width: 1px;height: 1px;margin: -1px;padding: 0;overflow: hidden;clip: rect(0, 0, 0, 0);border: 0;white-space: nowrap;}


### PR DESCRIPTION
## Summary
- manage accessibility features with client component
- update HTML classes for contrast, posture, language, and font size
- auto translate menu text based on selected language
- include manager in root layout and add basic styles

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621972eadc832d8066d7ba3c68a8c4