### PR TITLE
Add translation hook

### DIFF
--- a/src/components/partials/Keypad.js
+++ b/src/components/partials/Keypad.js
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import styles from "./Keypad.module.scss";
 import { useStore } from "../../../src/store/useStore";
+import useTranslate from "@/hooks/useTranslate";
 
 export default function Keypad() {
   const hydrated = useStore((state) => state.hydrated);
@@ -18,6 +19,8 @@ export default function Keypad() {
   const fontSize = useStore((state) => state.fontSize);
   const setFontSize = useStore((state) => state.setFontSize);
 
+  const t = useTranslate();
+
   const [openKey, setOpenKey] = useState(null);
 
   if (!hydrated) {
@@ -31,7 +34,7 @@ export default function Keypad() {
         <div className={styles.item}>
           <button type="button" onClick={() => setHighContrast(!highContrast)}>
             <span data-lang-code="고대비">고대비</span>
-            <strong>{highContrast ? "켜짐" : "꺼짐"}</strong>
+            <strong>{t(highContrast ? "켜짐" : "꺼짐")}</strong>
           </button>
         </div>
 
@@ -39,7 +42,7 @@ export default function Keypad() {
         <div className={styles.item}>
           <button type="button" onClick={() => setLowPosture(!lowPosture)}>
             <span data-lang-code="낮은자세">낮은자세</span>
-            <strong>{lowPosture ? "켜짐" : "꺼짐"}</strong>
+            <strong>{t(lowPosture ? "켜짐" : "꺼짐")}</strong>
           </button>
         </div>
 

--- a/src/hooks/useTranslate.js
+++ b/src/hooks/useTranslate.js
@@ -1,0 +1,15 @@
+"use client";
+import { useStore } from "@/store/useStore";
+import languageData from "@/../public/assets/data/language.json" assert { type: "json" };
+
+const LANG_MAP = { ko: "KO", en: "EN", jp: "JP", zh: "CH" };
+
+export default function useTranslate() {
+  const language = useStore((state) => state.language);
+  return (code) => {
+    const item = languageData.find((entry) => entry.code === code);
+    if (!item) return code;
+    const key = LANG_MAP[language] || "KO";
+    return item[key] || code;
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useTranslate` hook
- use the hook in `Keypad` so ON/OFF text changes with the selected language

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621f5be6dc832db1939a1c411b64a6