### PR TITLE
Fix language persistence across pages

### DIFF
--- a/public/assets/data/language.json
+++ b/public/assets/data/language.json
@@ -145,6 +145,20 @@
         "JP": "elTOV 顧客",
         "CH": "elTOV 客户",
         "EN": "elTOV Clients"
+    },
+    {
+        "code": "포트폴리오타이틀",
+        "KO": "포트폴리오",
+        "JP": "リファレンス",
+        "CH": "参考",
+        "EN": "References"
+    },
+    {
+        "code": "포트폴리오서브타이틀",
+        "KO": "엘토브의 프로젝트 사례",
+        "JP": "エルトブのプロジェクト事例",
+        "CH": "elTOV 项目案例",
+        "EN": "Projects by elTOV"
     }
 ]
            

--- a/src/app/(webpage)/references/page.js
+++ b/src/app/(webpage)/references/page.js
@@ -1,27 +1,18 @@
 'use client';
 
 import SubVisual from '../components/partials/subVisual/SubVisual';
-import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import styles from "./page.module.scss";
+import styles from './page.module.scss';
 
 export default function References() {
-    const [image, setImage] = useState("https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80");
-    const title = {"ko": "포트폴리오", "en": "REFERENCS" , };
-    const subtext = "subtext";
-
-    return (
-        <>
-            <SubVisual image={image} title={title} subtext={subtext} />
-            <div
-                className="sub_page_title"
-                style={{
-                    backgroundImage: `url('${image}')`,
-                }}
-            >
-                <h2>{title}</h2>
-                <div className="sub">{subtext}</div>
-            </div>
-        </>
-    );
+  const image = 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80';
+  return (
+    <>
+      <SubVisual
+        image={image}
+        titleCode="포트폴리오타이틀"
+        subtextCode="포트폴리오서브타이틀"
+      />
+      {/* page content here */}
+    </>
+  );
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,7 +2,7 @@ import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import Keypad from '../components/partials/keypad/Keypad';
 import Clients from '../components/partials/client/Clients';
-import AccessibilityManager from '../components/AccessibilityManager';
+import Providers from '../components/Providers';
 import '@/styles/reset.scss';
 import '@/styles/style.scss';
 
@@ -23,16 +23,17 @@ export default async function RootLayout({ children }) {
             <html lang="ko">
                 {/* MEMO: suppressHydrationWarning={true} 추가하면 extention의 불필요한 코드를 막음 */}
                 <body suppressHydrationWarning={true}>
-                    <AccessibilityManager />
-                    <div id="layout">
-                        {<Header/>}
-                        <div id="content">
-                            {children}
+                    <Providers>
+                        <div id="layout">
+                            {<Header/>}
+                            <div id="content">
+                                {children}
+                            </div>
+                            {<Keypad/>}
+                            {<Clients/>}
+                            {<Footer/>}
                         </div>
-                        {<Keypad/>}
-                        {<Clients/>}
-                        {<Footer/>}
-                    </div>
+                    </Providers>
                     <div id="portal"></div>
                 </body>
             </html>

--- a/src/components/AccessibilityManager.js
+++ b/src/components/AccessibilityManager.js
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { useStore } from "@/store/useStore";
 import languageData from "@/../public/assets/data/language.json" assert { type: "json" };
 
@@ -8,6 +9,7 @@ export default function AccessibilityManager() {
   const lowPosture = useStore((state) => state.lowPosture);
   const language = useStore((state) => state.language);
   const fontSize = useStore((state) => state.fontSize);
+  const pathname = usePathname();
 
   useEffect(() => {
     const html = document.documentElement;
@@ -37,7 +39,7 @@ export default function AccessibilityManager() {
         el.textContent = entry[key];
       }
     });
-  }, [language]);
+  }, [language, pathname]);
 
   return null;
 }

--- a/src/components/Providers.js
+++ b/src/components/Providers.js
@@ -1,0 +1,11 @@
+'use client';
+import AccessibilityManager from './AccessibilityManager';
+
+export default function Providers({ children }) {
+  return (
+    <>
+      <AccessibilityManager />
+      {children}
+    </>
+  );
+}

--- a/src/components/partials/subVisual/SubVisual.js
+++ b/src/components/partials/subVisual/SubVisual.js
@@ -1,18 +1,17 @@
 'use client';
 
-import styles from "./Subvisual.module.scss";
+import styles from './Subvisual.module.scss';
+import useTranslate from '@/hooks/useTranslate';
 
-export default function SubVisual() {
-    return (
-        <div className={style.sub_page_title}
-            style={{
-                backgroundImage: "url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=800&q=80')",
-            }}
-        >
-            <h2>포트폴리오</h2>
-            <div className={style.sub}></div>
-        </div>
-    );
+export default function SubVisual({ image, titleCode, subtextCode }) {
+  const translate = useTranslate();
+  return (
+    <div
+      className={styles.sub_page_title}
+      style={{ backgroundImage: `url('${image}')` }}
+    >
+      <h2>{translate(titleCode)}</h2>
+      <div className={styles.sub}>{translate(subtextCode)}</div>
+    </div>
+  );
 }
-
-

--- a/src/components/partials/subVisual/Subvisual.module.scss
+++ b/src/components/partials/subVisual/Subvisual.module.scss
@@ -1,0 +1,12 @@
+.sub_page_title {
+  position: relative;
+  padding: 120px 40px;
+  background-size: cover;
+  background-position: center;
+  color: #fff;
+  text-align: center;
+}
+.sub {
+  margin-top: 8px;
+  font-size: 1.8rem;
+}


### PR DESCRIPTION
## Summary
- create a small Provider component
- keep AccessibilityManager active on route changes
- wrap the app with Providers in layout
- flesh out SubVisual to translate by language
- store SubVisual strings in `language.json`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fcd50464832da088defdb167cd2c