### PR TITLE
Implement WordPress references page

### DIFF
--- a/src/app/(webpage)/references/[slug]/page.js
+++ b/src/app/(webpage)/references/[slug]/page.js
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+const API_BASE = 'https://eltov.com/home/wp-json/wp/v2';
+
+export default function ReferenceDetail({ params }) {
+  const { slug } = params;
+  const [post, setPost] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/posts?slug=${slug}&_embed`)
+      .then((res) => res.json())
+      .then((data) => setPost(data && data.length ? data[0] : null))
+      .catch((err) => console.error(err));
+  }, [slug]);
+
+  if (!post) {
+    return <div className="container">Loading...</div>;
+  }
+
+  const media = post._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+
+  return (
+    <div className="container">
+      <h1 dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
+      {media && <img src={media} alt={post.title.rendered} />}
+      <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
+    </div>
+  );
+}

--- a/src/app/(webpage)/references/page.js
+++ b/src/app/(webpage)/references/page.js
@@ -1,11 +1,14 @@
 "use client";
 import SubVisual from "@/components/partials/subVisual/SubVisual";
-import Link from 'next/link';
-import styles from "./page.module.scss";
+import CategoryList from "@/components/reference/CategoryList";
+import PostList from "@/components/reference/PostList";
+import { useSearchParams } from 'next/navigation';
 import useTranslate from '@/hooks/useTranslate';
 
 export default function References() {
     const translate = useTranslate();
+    const searchParams = useSearchParams();
+    const category = searchParams.get('cat');
     return (
         <>
         <SubVisual
@@ -17,25 +20,11 @@ export default function References() {
         <div className="container">
             <div className="category_tap">
                 <h3>{translate("카테고리타이틀")}</h3>
-                <ul>
-                    <li><Link href="#">카테고리명</Link></li>
-                </ul>
+                <CategoryList current={category} />
             </div>
 
             <div className="gall_list">
-                <ul>
-                    <li>
-                        <Link href="#">
-                            <div className="thum">
-                                <img src="" alt="" />
-                            </div>
-                            <div className="cnt">
-                                <div className="tit"></div>
-                                <div className="desc"></div>
-                            </div>
-                        </Link>
-                    </li>
-                </ul>
+                <PostList category={category} />
             </div>
         </div>
         </>

--- a/src/app/(webpage)/references/page.module.scss
+++ b/src/app/(webpage)/references/page.module.scss
@@ -1,0 +1,15 @@
+.category_tap ul {
+  display: flex;
+  gap: 10px;
+}
+
+.gall_list ul {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.gall_list .thum img {
+  width: 100%;
+  display: block;
+}

--- a/src/components/reference/CategoryList.js
+++ b/src/components/reference/CategoryList.js
@@ -1,0 +1,31 @@
+'use client';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const API_BASE = 'https://eltov.com/home/wp-json/wp/v2';
+
+export default function CategoryList({ current }) {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/categories`)
+      .then((res) => res.json())
+      .then((data) => setCategories(Array.isArray(data) ? data : []))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <ul>
+      {categories.map((cat) => (
+        <li key={cat.id}>
+          <Link
+            href={`/references?cat=${cat.id}`}
+            className={current == cat.id ? 'on' : ''}
+          >
+            {cat.name}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/reference/PostList.js
+++ b/src/components/reference/PostList.js
@@ -1,0 +1,45 @@
+'use client';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const API_BASE = 'https://eltov.com/home/wp-json/wp/v2';
+
+export default function PostList({ category }) {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    let url = `${API_BASE}/posts?_embed`;
+    if (category) url += `&categories=${category}`;
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => setPosts(Array.isArray(data) ? data : []))
+      .catch((err) => console.error(err));
+  }, [category]);
+
+  return (
+    <ul>
+      {posts.map((post) => {
+        const media = post._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+        return (
+          <li key={post.id}>
+            <Link href={`/references/${post.slug}`}>
+              <div className="thum">
+                {media && <img src={media} alt={post.title.rendered} />}
+              </div>
+              <div className="cnt">
+                <div
+                  className="tit"
+                  dangerouslySetInnerHTML={{ __html: post.title.rendered }}
+                />
+                <div
+                  className="desc"
+                  dangerouslySetInnerHTML={{ __html: post.excerpt.rendered }}
+                />
+              </div>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch categories from WordPress REST API
- fetch posts with optional category filter
- show list and category on References page
- add detailed view for each post
- basic styling for the new lists

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661d417034832daa11e0a501d401cd