### PR TITLE
Implement Firestore support and react-hook-form

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Firebase Setup
+
+This project uses Firebase Firestore. Create a `.env.local` file with the following keys:
+
+```
+NEXT_PUBLIC_FIREBASE_API_KEY=your-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-auth-domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-app-id
+```
+
+To insert sample data run:
+
+```
+node scripts/createDummyData.js
+```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "swiper": "^11.2.10",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "react-hook-form": "^7.50.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/scripts/createDummyData.js
+++ b/scripts/createDummyData.js
@@ -1,0 +1,15 @@
+import { collection, addDoc } from 'firebase/firestore';
+import { db } from '../src/firebase/firebaseConfig.js';
+import { portfolioData, kioskData } from '../src/firebase/dummyData.js';
+
+async function run() {
+  for (const item of portfolioData) {
+    await addDoc(collection(db, 'portfolio'), item);
+  }
+  for (const item of kioskData) {
+    await addDoc(collection(db, 'kiosk'), item);
+  }
+  console.log('Dummy data inserted');
+}
+
+run().catch(err => console.error(err));

--- a/src/app/(webpage)/contact/page.js
+++ b/src/app/(webpage)/contact/page.js
@@ -1,9 +1,19 @@
 "use client";
 import SubVisual from "@/components/partials/subVisual/SubVisual";
 import useTranslate from '@/hooks/useTranslate';
+import { useForm } from 'react-hook-form';
+import { addContact } from '@/firebase/firestore';
 
 export default function KioskHardware() {
   const translate = useTranslate();
+  const { register, handleSubmit, reset } = useForm();
+
+  const onSubmit = async (data) => {
+    await addContact(data);
+    alert('submitted');
+    reset();
+  };
+
   return (
     <>
       <SubVisual
@@ -13,43 +23,45 @@ export default function KioskHardware() {
       />
 
        <div id="sub_content" className="container">
-        <form action="">
+        <form onSubmit={handleSubmit(onSubmit)}>
             <div className="form">
                 <div className="item">
                     <div className="tit">{translate("성함")}</div>
                     <div className="input">
-                        <input type="text" />
+                        <input type="text" {...register('name')} />
                     </div>
                 </div>
                 <div className="item">
                     <div className="tit">{translate("전화번호")}</div>
                     <div className="input">
-                        <input type="tel" />
+                        <input type="tel" {...register('tel')} />
                     </div>
                 </div>
                 <div className="item">
                     <div className="tit">{translate("이메일")}</div>
                     <div className="input">
-                        <input type="email" />
+                        <input type="email" {...register('email')} />
                     </div>
                 </div>
                 <div className="item">
                     <div className="tit">{translate("문의분야")}</div>
                     <div className="input">
-                        <select name="" id="">
-                            <option value=""></option>
+                        <select {...register('category')}>
+                            <option value="">{translate('문의분야')}</option>
+                            <option value="A">A</option>
+                            <option value="B">B</option>
                         </select>
                     </div>
                 </div>
                 <div className="item">
                     <div className="tit">{translate("문의내용")}</div>
                     <div className="input">
-                        <textarea name="" id=""></textarea>
+                        <textarea {...register('description')} />
                     </div>
                 </div>
             </div>
             <div className="form_btns">
-                <button type="button">{translate("문의하기")}</button>
+                <button type="submit">{translate("문의하기")}</button>
             </div>
         </form>
       </div>

--- a/src/app/(webpage)/kiosk/[id]/page.js
+++ b/src/app/(webpage)/kiosk/[id]/page.js
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { getKiosk } from '@/firebase/firestore';
+
+export default function KioskDetail() {
+  const { id } = useParams();
+  const [item, setItem] = useState(null);
+  useEffect(() => {
+    if (!id) return;
+    getKiosk(id).then(setItem).catch(console.error);
+  }, [id]);
+  if (!item) return null;
+  return (
+    <div id="sub_content" className="container">
+      <h2>{item.title?.ko}</h2>
+      <p>{item.description?.ko}</p>
+      <div className="images">
+        {item.image_urls?.map((src, idx) => (
+          <img key={idx} src={src} alt="" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(webpage)/kiosk/page.js
+++ b/src/app/(webpage)/kiosk/page.js
@@ -1,0 +1,25 @@
+"use client";
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getKiosks } from '@/firebase/firestore';
+import useTranslate from '@/hooks/useTranslate';
+
+export default function KioskList() {
+  const [items, setItems] = useState([]);
+  const translate = useTranslate();
+  useEffect(() => {
+    getKiosks().then(setItems).catch(console.error);
+  }, []);
+  return (
+    <div id="sub_content" className="container">
+      <h2>{translate("메뉴kiosk")}</h2>
+      <ul>
+        {items.map((p) => (
+          <li key={p.id}>
+            <Link href={`/kiosk/${p.id}`}>{p.title?.ko}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(webpage)/portfolio/[id]/page.js
+++ b/src/app/(webpage)/portfolio/[id]/page.js
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { getPortfolio } from '@/firebase/firestore';
+
+export default function PortfolioDetail() {
+  const { id } = useParams();
+  const [item, setItem] = useState(null);
+  useEffect(() => {
+    if (!id) return;
+    getPortfolio(id).then(setItem).catch(console.error);
+  }, [id]);
+  if (!item) return null;
+  return (
+    <div id="sub_content" className="container">
+      <h2>{item.title?.ko}</h2>
+      <p>{item.description?.ko}</p>
+      <div className="images">
+        {item.image_urls?.map((src, idx) => (
+          <img key={idx} src={src} alt="" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(webpage)/portfolio/page.js
+++ b/src/app/(webpage)/portfolio/page.js
@@ -1,0 +1,25 @@
+"use client";
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getPortfolios } from '@/firebase/firestore';
+import useTranslate from '@/hooks/useTranslate';
+
+export default function PortfolioList() {
+  const [items, setItems] = useState([]);
+  const translate = useTranslate();
+  useEffect(() => {
+    getPortfolios().then(setItems).catch(console.error);
+  }, []);
+  return (
+    <div id="sub_content" className="container">
+      <h2>{translate("포트폴리오타이틀")}</h2>
+      <ul>
+        {items.map((p) => (
+          <li key={p.id}>
+            <Link href={`/portfolio/${p.id}`}>{p.title?.ko}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -20,6 +20,8 @@ export default function Header() {
                         <li><Link href="#">{translate("메뉴way")}</Link></li>
                         <li><Link href="#">{translate("메뉴media")}</Link></li>
                         <li><Link href="/hardware">{translate("메뉴hw")}</Link></li>
+                        <li><Link href="/portfolio">{translate("포트폴리오타이틀")}</Link></li>
+                        <li><Link href="/kiosk">Kiosk</Link></li>
                         <li><Link href="/references">{translate("메뉴references")}</Link></li>
                         <li><Link href="#">{translate("메뉴about")}</Link></li>
                     </ul>

--- a/src/firebase/dummyData.js
+++ b/src/firebase/dummyData.js
@@ -1,0 +1,39 @@
+export const portfolioData = Array.from({ length: 20 }).map((_, i) => ({
+  title: {
+    en: `Portfolio ${i + 1}`,
+    ko: `포트폴리오 ${i + 1}`,
+    jp: `ポートフォリオ ${i + 1}`,
+    cn: `作品集 ${i + 1}`,
+  },
+  description: {
+    en: `Portfolio description ${i + 1}`,
+    ko: `포트폴리오 설명 ${i + 1}`,
+    jp: `ポートフォリオ説明 ${i + 1}`,
+    cn: `作品集説明 ${i + 1}`,
+  },
+  createdAt: new Date().toISOString(),
+  thum_url: `https://picsum.photos/seed/portfolio${i}/300/200`,
+  image_urls: [`https://picsum.photos/seed/portfolio${i}a/600/400`],
+  video_urls: [],
+  category: 'default',
+}));
+
+export const kioskData = Array.from({ length: 20 }).map((_, i) => ({
+  title: {
+    en: `Kiosk ${i + 1}`,
+    ko: `키오스크 ${i + 1}`,
+    jp: `キオスク ${i + 1}`,
+    cn: `亭 ${i + 1}`,
+  },
+  description: {
+    en: `Kiosk description ${i + 1}`,
+    ko: `키오스크 설명 ${i + 1}`,
+    jp: `キオスク説明 ${i + 1}`,
+    cn: `亭説明 ${i + 1}`,
+  },
+  createdAt: new Date().toISOString(),
+  thum_url: `https://picsum.photos/seed/kiosk${i}/300/200`,
+  image_urls: [`https://picsum.photos/seed/kiosk${i}a/600/400`],
+  video_urls: [],
+  category: 'default',
+}));

--- a/src/firebase/firebaseConfig.js
+++ b/src/firebase/firebaseConfig.js
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/firebase/firestore.js
+++ b/src/firebase/firestore.js
@@ -1,0 +1,26 @@
+import { collection, getDocs, getDoc, doc, addDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from './firebaseConfig';
+
+export async function getPortfolios() {
+  const snapshot = await getDocs(collection(db, 'portfolio'));
+  return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function getPortfolio(id) {
+  const snap = await getDoc(doc(db, 'portfolio', id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+export async function getKiosks() {
+  const snapshot = await getDocs(collection(db, 'kiosk'));
+  return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function getKiosk(id) {
+  const snap = await getDoc(doc(db, 'kiosk', id));
+  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+export async function addContact(data) {
+  await addDoc(collection(db, 'contact'), { ...data, createdAt: serverTimestamp() });
+}


### PR DESCRIPTION
## Summary
- integrate Firebase Firestore
- add dummy portfolio/kiosk data generation script
- implement portfolio and kiosk list/detail pages
- update contact page to use react-hook-form and store to Firestore
- document Firebase setup

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68675b5e8fc4832d82f2ce463b68901b