### PR TITLE
Fix category filtering and localization

### DIFF
--- a/src/app/(webpage)/kiosk/[id]/page.js
+++ b/src/app/(webpage)/kiosk/[id]/page.js
@@ -1,20 +1,38 @@
 "use client";
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import { getKiosk } from '@/firebase/firestore';
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { getKiosk } from "@/firebase/firestore";
+import { useStore } from "@/store/useStore";
 
 export default function KioskDetail() {
   const { id } = useParams();
   const [item, setItem] = useState(null);
+  const language = useStore((state) => state.language);
   useEffect(() => {
     if (!id) return;
     getKiosk(id).then(setItem).catch(console.error);
   }, [id]);
   if (!item) return null;
+  const title =
+    language === "ko"
+      ? item.title_ko
+      : language === "en"
+        ? item.title_en
+        : language === "jp"
+          ? item.title_jp
+          : item.title_cn;
+  const desc =
+    language === "ko"
+      ? item.description_ko
+      : language === "en"
+        ? item.description_en
+        : language === "jp"
+          ? item.description_jp
+          : item.description_cn;
   return (
     <div id="sub_content" className="container">
-      <h2>{item.title?.ko}</h2>
-      <p>{item.description?.ko}</p>
+      <h2>{title}</h2>
+      <p>{desc}</p>
       <div className="images">
         {item.image_urls?.map((src, idx) => (
           <img key={idx} src={src} alt="" />

--- a/src/app/(webpage)/kiosk/page.js
+++ b/src/app/(webpage)/kiosk/page.js
@@ -1,25 +1,44 @@
 "use client";
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { getKiosks } from '@/firebase/firestore';
-import useTranslate from '@/hooks/useTranslate';
+import { useEffect, useState } from "react";
+import { getKiosks, getKioskCategories } from "@/firebase/firestore";
+import useTranslate from "@/hooks/useTranslate";
+import SubVisual from "@/components/partials/subVisual/SubVisual";
+import CategoryList from "@/components/partials/board/CategoryList";
+import GallList from "@/components/partials/board/GallList";
 
 export default function KioskList() {
   const [items, setItems] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [selectedCategory, setSelectedCategory] = useState("전체");
   const translate = useTranslate();
   useEffect(() => {
     getKiosks().then(setItems).catch(console.error);
+    getKioskCategories().then(setCategories).catch(console.error);
   }, []);
+  const handleCategoryChange = (code) => {
+    setSelectedCategory(code);
+  };
+
+  const filteredItems = items.filter((item) => {
+    if (selectedCategory === "전체") return true;
+    return item.category_code === selectedCategory;
+  });
+
   return (
-    <div id="sub_content" className="container">
-      <h2>{translate("메뉴kiosk")}</h2>
-      <ul>
-        {items.map((p) => (
-          <li key={p.id}>
-            <Link href={`/kiosk/${p.id}`}>{p.title?.ko}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <>
+      <SubVisual
+        image="https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=800&q=80"
+        titleCode="메뉴kiosk"
+        subtextCode="메뉴kiosk"
+      />
+      <div id="sub_content" className="container">
+        <CategoryList
+          categories={categories}
+          selectedCategory={selectedCategory}
+          handleCategoryChange={handleCategoryChange}
+        />
+        <GallList items={filteredItems} linkPrefix="/kiosk" />
+      </div>
+    </>
   );
 }

--- a/src/app/(webpage)/portfolio/[id]/page.js
+++ b/src/app/(webpage)/portfolio/[id]/page.js
@@ -1,20 +1,38 @@
 "use client";
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import { getPortfolio } from '@/firebase/firestore';
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { getPortfolio } from "@/firebase/firestore";
+import { useStore } from "@/store/useStore";
 
 export default function PortfolioDetail() {
   const { id } = useParams();
   const [item, setItem] = useState(null);
+  const language = useStore((state) => state.language);
   useEffect(() => {
     if (!id) return;
     getPortfolio(id).then(setItem).catch(console.error);
   }, [id]);
   if (!item) return null;
+  const title =
+    language === "ko"
+      ? item.title_ko
+      : language === "en"
+        ? item.title_en
+        : language === "jp"
+          ? item.title_jp
+          : item.title_cn;
+  const desc =
+    language === "ko"
+      ? item.description_ko
+      : language === "en"
+        ? item.description_en
+        : language === "jp"
+          ? item.description_jp
+          : item.description_cn;
   return (
     <div id="sub_content" className="container">
-      <h2>{item.title?.ko}</h2>
-      <p>{item.description?.ko}</p>
+      <h2>{title}</h2>
+      <p>{desc}</p>
       <div className="images">
         {item.image_urls?.map((src, idx) => (
           <img key={idx} src={src} alt="" />

--- a/src/app/(webpage)/portfolio/page.js
+++ b/src/app/(webpage)/portfolio/page.js
@@ -1,126 +1,132 @@
-'use client';
-import { useEffect, useState } from 'react';
-import { getPortfolios, getPortfolioCategories } from '@/firebase/firestore';
+"use client";
+import { useEffect, useState } from "react";
+import { getPortfolios, getPortfolioCategories } from "@/firebase/firestore";
 import SubVisual from "@/components/partials/subVisual/SubVisual";
 import CategoryList from "@/components/partials/board/CategoryList";
 import GallList from "@/components/partials/board/GallList";
-import { useRouter } from 'next/navigation';
+import { useRouter } from "next/navigation";
 
 export default function PortfolioList() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
-  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const [selectedCategory, setSelectedCategory] = useState("전체");
   const router = useRouter();
 
   useEffect(() => {
-    getPortfolios().then(data => {
-      setItems(data);
-        {console.log(data)}
-//         [
-//     {
-//         "id": "7cTSWr4C7CsGOHudsML4",
-//         "image_urls": [
-//             "https://example.com/img2.jpg",
-//             "https://example.com/img3.jpg"
-//         ],
-//         "thum_url": "https://example.com/thumb1.jpg",
-//         "title_jp": "サンプルポートフォリオ jp123",
-//         "category_code": "터치디스플레이세로형",
-//         "video_urls": [
-//             "https://example.com/video1.mp4"
-//         ],
-//         "title_cn": "示例作品集 123CN",
-//         "description_ko": "이것은 한국어 샘플 설명입니다.123",
-//         "createdAt": {
-//             "type": "firestore/timestamp/1.0",
-//             "seconds": 1751611842,
-//             "nanoseconds": 244000000
-//         },
-//         "description_en": "This is a sample 123portfolio description in English.",
-//         "title_ko": "샘플 포트폴리오 KO123",
-//         "description_cn": "这是中文示例说明。123",
-//         "title_en": "Sample Portfolio en123",
-//         "description_jp": "これは日本語のサンプル説明です。123"
-//     },
-//     {
-//         "id": "CVwQqhe5Ewmpur0BlPSo",
-//         "title_en": "Sample Portfolio en123",
-//         "description_jp": "これは日本語のサンプル説明です。123",
-//         "category_code": "터치디스플레이가로형",
-//         "title_jp": "サンプルポートフォリオ jp123",
-//         "thum_url": "https://example.com/thumb1.jpg",
-//         "image_urls": [
-//             "https://example.com/img2.jpg",
-//             "https://example.com/img3.jpg"
-//         ],
-//         "title_cn": "示例作品集 123CN",
-//         "description_ko": "이것은 한국어 샘플 설명입니다.123",
-//         "description_cn": "这是中文示例说明。123",
-//         "video_urls": [
-//             "https://example.com/video1.mp4"
-//         ],
-//         "description_en": "This is a sample 123portfolio description in English.",
-//         "title_ko": "샘플 포트폴리오 KO123",
-//         "createdAt": {
-//             "type": "firestore/timestamp/1.0",
-//             "seconds": 1751611842,
-//             "nanoseconds": 195000000
-//         }
-//     }
-// ]
-    }).catch(console.error);
+    getPortfolios()
+      .then((data) => {
+        setItems(data);
+        {
+          console.log(data);
+        }
+        //         [
+        //     {
+        //         "id": "7cTSWr4C7CsGOHudsML4",
+        //         "image_urls": [
+        //             "https://example.com/img2.jpg",
+        //             "https://example.com/img3.jpg"
+        //         ],
+        //         "thum_url": "https://example.com/thumb1.jpg",
+        //         "title_jp": "サンプルポートフォリオ jp123",
+        //         "category_code": "터치디스플레이세로형",
+        //         "video_urls": [
+        //             "https://example.com/video1.mp4"
+        //         ],
+        //         "title_cn": "示例作品集 123CN",
+        //         "description_ko": "이것은 한국어 샘플 설명입니다.123",
+        //         "createdAt": {
+        //             "type": "firestore/timestamp/1.0",
+        //             "seconds": 1751611842,
+        //             "nanoseconds": 244000000
+        //         },
+        //         "description_en": "This is a sample 123portfolio description in English.",
+        //         "title_ko": "샘플 포트폴리오 KO123",
+        //         "description_cn": "这是中文示例说明。123",
+        //         "title_en": "Sample Portfolio en123",
+        //         "description_jp": "これは日本語のサンプル説明です。123"
+        //     },
+        //     {
+        //         "id": "CVwQqhe5Ewmpur0BlPSo",
+        //         "title_en": "Sample Portfolio en123",
+        //         "description_jp": "これは日本語のサンプル説明です。123",
+        //         "category_code": "터치디스플레이가로형",
+        //         "title_jp": "サンプルポートフォリオ jp123",
+        //         "thum_url": "https://example.com/thumb1.jpg",
+        //         "image_urls": [
+        //             "https://example.com/img2.jpg",
+        //             "https://example.com/img3.jpg"
+        //         ],
+        //         "title_cn": "示例作品集 123CN",
+        //         "description_ko": "이것은 한국어 샘플 설명입니다.123",
+        //         "description_cn": "这是中文示例说明。123",
+        //         "video_urls": [
+        //             "https://example.com/video1.mp4"
+        //         ],
+        //         "description_en": "This is a sample 123portfolio description in English.",
+        //         "title_ko": "샘플 포트폴리오 KO123",
+        //         "createdAt": {
+        //             "type": "firestore/timestamp/1.0",
+        //             "seconds": 1751611842,
+        //             "nanoseconds": 195000000
+        //         }
+        //     }
+        // ]
+      })
+      .catch(console.error);
 
-    getPortfolioCategories().then(data => {
+    getPortfolioCategories()
+      .then((data) => {
         setCategories(data);
-        setSelectedCategory('전체');
+        setSelectedCategory("전체");
 
-        {console.log(data)}
+        {
+          console.log(data);
+        }
 
-//         [
-//     {
-//         "id": "7OFylCGYDAcBthPOIkPV",
-//         "ch": "购物中心",
-//         "index": 7,
-//         "en": "Shopping Mall",
-//         "ko": "쇼핑몰",
-//         "code": "쇼핑몰",
-//         "jp": "ショッピングモール"
-//     },
-//     {
-//         "id": "7gxSAqGrjSd9laHUR3NY",
-//         "en": "Education",
-//         "index": 1,
-//         "code": "교육",
-//         "ko": "교육",
-//         "jp": "教育",
-//         "ch": "教育"
-//     },
-//     {
-//         "id": "8kSkQAtMMvH0EyUO1qSb",
-//         "en": "Showcase",
-//         "ko": "쇼케이스",
-//         "ch": "展示",
-//         "index": 8,
-//         "jp": "ショーケース",
-//         "code": "쇼케이스"
-//     },
-// ]
-
-    }).catch(console.error);
+        //         [
+        //     {
+        //         "id": "7OFylCGYDAcBthPOIkPV",
+        //         "ch": "购物中心",
+        //         "index": 7,
+        //         "en": "Shopping Mall",
+        //         "ko": "쇼핑몰",
+        //         "code": "쇼핑몰",
+        //         "jp": "ショッピングモール"
+        //     },
+        //     {
+        //         "id": "7gxSAqGrjSd9laHUR3NY",
+        //         "en": "Education",
+        //         "index": 1,
+        //         "code": "교육",
+        //         "ko": "교육",
+        //         "jp": "教育",
+        //         "ch": "教育"
+        //     },
+        //     {
+        //         "id": "8kSkQAtMMvH0EyUO1qSb",
+        //         "en": "Showcase",
+        //         "ko": "쇼케이스",
+        //         "ch": "展示",
+        //         "index": 8,
+        //         "jp": "ショーケース",
+        //         "code": "쇼케이스"
+        //     },
+        // ]
+      })
+      .catch(console.error);
   }, []);
 
-  const handleCategoryChange = (category) => {
-    setSelectedCategory(category);
-    setLanguage(category);
+  const handleCategoryChange = (code) => {
+    setSelectedCategory(code);
     router.push({
-      pathname: '/portfolio',
-      query: { category: category },
+      pathname: "/portfolio",
+      query: { category: code },
     });
   };
 
   const filteredItems = items.filter((item) => {
-    if (selectedCategory === '전체') return true;
-    return item.category === selectedCategory;
+    if (selectedCategory === "전체") return true;
+    return item.category_code === selectedCategory;
   });
 
   return (
@@ -136,7 +142,7 @@ export default function PortfolioList() {
           selectedCategory={selectedCategory}
           handleCategoryChange={handleCategoryChange}
         />
-        <GallList items={filteredItems} />
+        <GallList items={filteredItems} linkPrefix="/portfolio" />
       </div>
     </>
   );

--- a/src/components/partials/board/CategoryList.js
+++ b/src/components/partials/board/CategoryList.js
@@ -2,29 +2,42 @@
 import Link from "next/link";
 import styles from "./CategoryList.module.scss";
 import { useStore } from "../../../store/useStore";
+import useTranslate from "@/hooks/useTranslate";
 
-export default function CategoryList({ categories, selectedCategory, handleCategoryChange }) {
+export default function CategoryList({
+  categories,
+  selectedCategory,
+  handleCategoryChange,
+}) {
   const language = useStore((state) => state.language);
+  const translate = useTranslate();
   return (
     <div className={styles.category_tap}>
-      <h3>분류선택</h3>
+      <h3>{translate("분류선택")}</h3>
       <ul>
+        <li>
+          <Link
+            href="#"
+            className={selectedCategory === "전체" ? "active" : ""}
+            onClick={() => handleCategoryChange("전체")}
+          >
+            {translate("전체")}
+          </Link>
+        </li>
         {categories.map((category, index) => (
           <li key={index}>
             <Link
               href="#"
-              className={category === selectedCategory ? 'active' : ''}
-              onClick={() => handleCategoryChange(category)}
+              className={category.code === selectedCategory ? "active" : ""}
+              onClick={() => handleCategoryChange(category.code)}
             >
-                {language}
               {language === "ko"
                 ? category.ko
                 : language === "en"
-                ? category.en
-                : language === "jp"
-                ? category.jp
-                : category.cn
-                }
+                  ? category.en
+                  : language === "jp"
+                    ? category.jp
+                    : category.ch}
             </Link>
           </li>
         ))}

--- a/src/components/partials/board/GallList.js
+++ b/src/components/partials/board/GallList.js
@@ -1,17 +1,17 @@
-'use client';
-import Link from 'next/link';
+"use client";
+import Link from "next/link";
 import styles from "./GallList.module.scss";
-import useTranslate from '@/hooks/useTranslate';
+import useTranslate from "@/hooks/useTranslate";
 import { useStore } from "../../../store/useStore";
 
-export default function GallList({items}) {
+export default function GallList({ items, linkPrefix = "" }) {
   const language = useStore((state) => state.language);
   return (
     <div className={styles.gall_list}>
       <ul>
         {items.map((item, idx) => (
           <li key={idx}>
-            <Link href="#">
+            <Link href={linkPrefix ? `${linkPrefix}/${item.id}` : "#"}>
               <div className={styles.thum}>
                 <img src={item.thum_url} />
               </div>
@@ -20,21 +20,19 @@ export default function GallList({items}) {
                   {language === "ko"
                     ? item.title_ko
                     : language === "en"
-                    ? item.title_en
-                    : language === "jp"
-                    ? item.title_jp
-                    : item.title_cn
-                  }
+                      ? item.title_en
+                      : language === "jp"
+                        ? item.title_jp
+                        : item.title_cn}
                 </div>
                 <div className={styles.desc}>
-                   {language === "ko"
+                  {language === "ko"
                     ? item.description_ko
                     : language === "en"
-                    ? item.description_en
-                    : language === "jp"
-                    ? item.description_jp
-                    : item.description_cn
-                  }
+                      ? item.description_en
+                      : language === "jp"
+                        ? item.description_jp
+                        : item.description_cn}
                 </div>
               </div>
             </Link>

--- a/src/firebase/firestore.js
+++ b/src/firebase/firestore.js
@@ -1,31 +1,46 @@
-import { collection, getDocs, getDoc, doc, addDoc, serverTimestamp } from 'firebase/firestore';
-import { db } from './firebaseConfig';
+import {
+  collection,
+  getDocs,
+  getDoc,
+  doc,
+  addDoc,
+  serverTimestamp,
+} from "firebase/firestore";
+import { db } from "./firebaseConfig";
 
 export async function getPortfolioCategories() {
-  const snapshot = await getDocs(collection(db, 'portfolio_category'));
-  return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+  const snapshot = await getDocs(collection(db, "portfolio_category"));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+export async function getKioskCategories() {
+  const snapshot = await getDocs(collection(db, "kiosk_category"));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }
 
 export async function getPortfolios() {
-  const snapshot = await getDocs(collection(db, 'portfolio'));
-  return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+  const snapshot = await getDocs(collection(db, "portfolio"));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }
 
 export async function getPortfolio(id) {
-  const snap = await getDoc(doc(db, 'portfolio', id));
+  const snap = await getDoc(doc(db, "portfolio", id));
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 export async function getKiosks() {
-  const snapshot = await getDocs(collection(db, 'kiosk'));
-  return snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+  const snapshot = await getDocs(collection(db, "kiosk"));
+  return snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
 }
 
 export async function getKiosk(id) {
-  const snap = await getDoc(doc(db, 'kiosk', id));
+  const snap = await getDoc(doc(db, "kiosk", id));
   return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 export async function addContact(data) {
-  await addDoc(collection(db, 'contact'), { ...data, createdAt: serverTimestamp() });
+  await addDoc(collection(db, "contact"), {
+    ...data,
+    createdAt: serverTimestamp(),
+  });
 }


### PR DESCRIPTION
## Summary
- show translated categories and include 'All'
- link gallery items to detail pages
- filter by category code
- localize portfolio and kiosk detail pages
- add kiosk categories
- extend Kiosk page with category filtering

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678b26c020832d993595d2852ee5d0