### PR TITLE
Fix category filter persistence

### DIFF
--- a/src/app/(webpage)/kiosk/page.js
+++ b/src/app/(webpage)/kiosk/page.js
@@ -5,18 +5,29 @@ import useTranslate from "@/hooks/useTranslate";
 import SubVisual from "@/components/partials/subVisual/SubVisual";
 import CategoryList from "@/components/partials/board/CategoryList";
 import GallList from "@/components/partials/board/GallList";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function KioskList() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const translate = useTranslate();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   useEffect(() => {
     getKiosks().then(setItems).catch(console.error);
     getKioskCategories().then(setCategories).catch(console.error);
   }, []);
+
+  useEffect(() => {
+    const param = searchParams.get("category");
+    if (param) setSelectedCategory(param);
+  }, [searchParams]);
+
   const handleCategoryChange = (code) => {
     setSelectedCategory(code);
+    router.push({ pathname: "/kiosk", query: { category: code } });
   };
 
   const filteredItems = items.filter((item) => {

--- a/src/app/(webpage)/portfolio/page.js
+++ b/src/app/(webpage)/portfolio/page.js
@@ -4,13 +4,14 @@ import { getPortfolios, getPortfolioCategories } from "@/firebase/firestore";
 import SubVisual from "@/components/partials/subVisual/SubVisual";
 import CategoryList from "@/components/partials/board/CategoryList";
 import GallList from "@/components/partials/board/GallList";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function PortfolioList() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     getPortfolios()
@@ -77,7 +78,8 @@ export default function PortfolioList() {
     getPortfolioCategories()
       .then((data) => {
         setCategories(data);
-        setSelectedCategory("전체");
+        const param = searchParams.get("category");
+        setSelectedCategory(param || "전체");
 
         {
           console.log(data);
@@ -114,7 +116,7 @@ export default function PortfolioList() {
         // ]
       })
       .catch(console.error);
-  }, []);
+  }, [searchParams]);
 
   const handleCategoryChange = (code) => {
     setSelectedCategory(code);

--- a/src/components/partials/board/CategoryList.js
+++ b/src/components/partials/board/CategoryList.js
@@ -19,7 +19,10 @@ export default function CategoryList({
           <Link
             href="#"
             className={selectedCategory === "전체" ? "active" : ""}
-            onClick={() => handleCategoryChange("전체")}
+            onClick={(e) => {
+              e.preventDefault();
+              handleCategoryChange("전체");
+            }}
           >
             {translate("전체")}
           </Link>
@@ -29,7 +32,10 @@ export default function CategoryList({
             <Link
               href="#"
               className={category.code === selectedCategory ? "active" : ""}
-              onClick={() => handleCategoryChange(category.code)}
+              onClick={(e) => {
+                e.preventDefault();
+                handleCategoryChange(category.code);
+              }}
             >
               {language === "ko"
                 ? category.ko


### PR DESCRIPTION
## Summary
- keep selected category across refresh in `/kiosk` and `/portfolio`
- prevent scrolling to page top when clicking a category

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686792804ba0832db1abbd8ff4145687