### PR TITLE
Wrap board pages in Suspense

### DIFF
--- a/src/app/(webpage)/kiosk/page.js
+++ b/src/app/(webpage)/kiosk/page.js
@@ -7,7 +7,9 @@ import CategoryList from "@/components/partials/board/CategoryList";
 import GallList from "@/components/partials/board/GallList";
 import { useRouter, useSearchParams } from "next/navigation";
 
-export default function KioskList() {
+import { Suspense } from "react";
+
+function KioskListContent() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("전체");
@@ -52,5 +54,13 @@ export default function KioskList() {
         </div>
       </div>
     </>
+  );
+}
+
+export default function KioskList() {
+  return (
+    <Suspense fallback={null}>
+      <KioskListContent />
+    </Suspense>
   );
 }

--- a/src/app/(webpage)/portfolio/page.js
+++ b/src/app/(webpage)/portfolio/page.js
@@ -7,7 +7,9 @@ import GallList from "@/components/partials/board/GallList";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
-export default function PortfolioList() {
+import { Suspense } from "react";
+
+function PortfolioListContent() {
   const [items, setItems] = useState([]);
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState("전체");
@@ -62,5 +64,13 @@ export default function PortfolioList() {
         <GallList items={filteredItems} linkPrefix="/portfolio" />
       </div>
     </>
+  );
+}
+
+export default function PortfolioList() {
+  return (
+    <Suspense fallback={null}>
+      <PortfolioListContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- add a Suspense boundary around the kiosk and portfolio pages

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688af63b29d4832da50790b803d72924